### PR TITLE
Add MAX_FAN ceiling and flatten fan curves for noise optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   re-discovery on Home Assistant restart. Single-file, stdlib-only python3
   MQTT 3.1.1 client — no apt packages, so it survives UniFi OS firmware
   updates. Inactive unless `/root/mqtt_bridge.conf` exists.
-- Fan-curve tuning from Home Assistant: `SYS_TGT`, `HDD_TGT`, `SSD_TGT`, and
-  `MIN_FAN` exposed as number entities. Values are clamped to ranges that stay
-  below the fixed `*_MAX` ceilings and persisted to `/root/fan_control.conf`.
+- Fan-curve tuning from Home Assistant: `SYS_TGT`, `HDD_TGT`, `SSD_TGT`,
+  `MIN_FAN`, and `MAX_FAN` exposed as number entities. Values are clamped to
+  ranges that stay below the fixed `*_MAX` ceilings and persisted to
+  `/root/fan_control.conf`.
+- `MAX_FAN` parameter in `fan_control.sh`: a fan speed ceiling (default 255)
+  the curves ramp to at their MAX temps, for capping fan noise. It caps the
+  fans even when overheating; an invalid value (below `MIN_FAN` or above 255)
+  fails hot with the full range.
 - `fan_control_state.sh`: optional helper sourced by `fan_control.sh`
   providing the conf-override and state-snapshot hooks. Snapshots (an atomic
   JSON file at `/run/fan_control/state.json`, root-only, including drive
@@ -26,6 +31,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   can neither crash fan control nor execute code.
 
 ### Changed
+- Default `SYS_MAX` 75 → 85 and `HDD_MAX` 50 → 55. Wider TGT..MAX spans
+  flatten the fan-curve slope (fewer PWM steps per °C), so temperature
+  wobbles no longer swing the fans audibly; both ceilings remain within
+  SoC throttle and HDD rating limits.
 - `fan_control.sh`: defines no-op hook stubs and calls them each iteration;
   installing `fan_control_state.sh` replaces the stubs. Drive serial numbers
   are passed to the state snapshot (console output is unchanged). A missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased: Optional MQTT / Home Assistant bridge.
+
+### Added
+- `mqtt_bridge.py` + `mqtt_bridge.service`: an optional, opt-in bridge that
+  publishes temperatures, fan duty, and fan RPM to an MQTT broker with Home
+  Assistant device-based discovery (HA ≥ 2024.9), including per-drive
+  temperature sensors keyed by serial number, availability (LWT), and
+  re-discovery on Home Assistant restart. Single-file, stdlib-only python3
+  MQTT 3.1.1 client — no apt packages, so it survives UniFi OS firmware
+  updates. Inactive unless `/root/mqtt_bridge.conf` exists.
+- Fan-curve tuning from Home Assistant: `SYS_TGT`, `HDD_TGT`, `SSD_TGT`, and
+  `MIN_FAN` exposed as number entities. Values are clamped to ranges that stay
+  below the fixed `*_MAX` ceilings and persisted to `/root/fan_control.conf`.
+- `fan_control_state.sh`: optional helper sourced by `fan_control.sh`
+  providing the conf-override and state-snapshot hooks. Snapshots (an atomic
+  JSON file at `/run/fan_control/state.json`, root-only, including drive
+  serial numbers) are only written once `/root/mqtt_bridge.conf` exists, so
+  non-MQTT installs do no extra work. Overrides are parsed against a strict
+  key/integer allowlist — the conf file is never `source`d, so a corrupt file
+  can neither crash fan control nor execute code.
+
+### Changed
+- `fan_control.sh`: defines no-op hook stubs and calls them each iteration;
+  installing `fan_control_state.sh` replaces the stubs. Drive serial numbers
+  are passed to the state snapshot (console output is unchanged). A missing
+  or broken helper file leaves the stubs in place — fan control never depends
+  on the MQTT feature.
+- `deploy.sh`: also deploys the bridge files and unit (inert without a conf).
+
 ## 2026-06-25: Overhaul to support all UNAS devices correctly.
 
 ### Added

--- a/MQTT.md
+++ b/MQTT.md
@@ -19,9 +19,11 @@ under **Settings → Devices & Services → MQTT** as "UNAS Fan Control".
   classes actually present — no phantom 0°C sensors), one temperature per
   drive (keyed by drive serial number, stable across `/dev` renames), fan
   duty %, and fan RPM per tachometer.
-- **Numbers (configuration):** `System target temp` (35–65°C), `HDD target
-  temp` (25–45°C), `SSD target temp` (35–62°C), `Minimum fan speed` (10–100%).
-  These map to `SYS_TGT`/`HDD_TGT`/`SSD_TGT`/`MIN_FAN` and persist in
+- **Numbers (configuration):** `System target temp` (35–70°C), `HDD target
+  temp` (25–45°C), `SSD target temp` (35–62°C), `Minimum fan speed` (5–100%),
+  `Maximum fan speed` (30–100%; caps the curve even when overheating, and is
+  ignored — full range used — if set below the minimum fan speed).
+  These map to `SYS_TGT`/`HDD_TGT`/`SSD_TGT`/`MIN_FAN`/`MAX_FAN` and persist in
   `/root/fan_control.conf`, which `fan_control.sh` re-reads (strict allowlist,
   integers only — never `source`d) every minute. Slider ranges are capped
   below the fixed `*_MAX` ceilings so the curve cannot be inverted from Home

--- a/MQTT.md
+++ b/MQTT.md
@@ -1,0 +1,130 @@
+# MQTT / Home Assistant Bridge (Optional)
+
+The optional `mqtt_bridge` service publishes temperatures and fan speeds to an
+MQTT broker (e.g. mosquitto) with [Home Assistant MQTT
+discovery](https://www.home-assistant.io/integrations/mqtt/), and lets you tune
+the fan curve's target temperatures from Home Assistant.
+
+It is fully opt-in: without `/root/mqtt_bridge.conf` the bridge service stays
+inactive and the state-snapshot hooks in `fan_control.sh` are no-ops. Fan
+control never depends on the bridge — if MQTT, the broker, or the network is
+down (or the bridge crashes), the fan loop keeps running untouched.
+
+## Entities
+
+Device-based discovery (requires Home Assistant ≥ 2024.9). The device appears
+under **Settings → Devices & Services → MQTT** as "UNAS Fan Control".
+
+- **Sensors:** max system temperature, max HDD/SSD temperature (only for drive
+  classes actually present — no phantom 0°C sensors), one temperature per
+  drive (keyed by drive serial number, stable across `/dev` renames), fan
+  duty %, and fan RPM per tachometer.
+- **Numbers (configuration):** `System target temp` (35–65°C), `HDD target
+  temp` (25–45°C), `SSD target temp` (35–62°C), `Minimum fan speed` (10–100%).
+  These map to `SYS_TGT`/`HDD_TGT`/`SSD_TGT`/`MIN_FAN` and persist in
+  `/root/fan_control.conf`, which `fan_control.sh` re-reads (strict allowlist,
+  integers only — never `source`d) every minute. Slider ranges are capped
+  below the fixed `*_MAX` ceilings so the curve cannot be inverted from Home
+  Assistant; `*_MAX` values stay file-edit only by design.
+
+All entities go `unavailable` if the device stops reporting for 3 minutes —
+including when `fan_control.service` is stopped while the bridge is still
+running, so a dead fan loop is never mistaken for a healthy one.
+
+> [!NOTE]
+> Once the bridge has written `/root/fan_control.conf`, those values override
+> the defaults at the top of `fan_control.sh` on every loop. If you later edit
+> the script defaults directly, delete `/root/fan_control.conf` (or re-tune
+> from Home Assistant) for the edits to take effect.
+
+## Setup
+
+```bash
+# 1. Create a broker user (on the broker/Home Assistant side), e.g.:
+#    mosquitto_passwd /etc/mosquitto/passwd unas
+
+# 2. On the UNAS, create the config (deploy.sh copies the example over):
+cp /root/mqtt_bridge.conf.example /root/mqtt_bridge.conf
+chmod 600 /root/mqtt_bridge.conf
+vi /root/mqtt_bridge.conf   # set MQTT_HOST/MQTT_USER/MQTT_PASS
+
+# 3. Start the bridge:
+systemctl restart mqtt_bridge.service
+systemctl status mqtt_bridge.service
+```
+
+Running more than one UNAS against the same broker? Set a distinct
+`MQTT_DEVICE_ID` on each device — it defaults to the hostname, and two devices
+with the same id will fight over one MQTT session and overwrite each other's
+entities in Home Assistant.
+
+### Broker security recommendations
+
+- **Restrict the command topics with an ACL.** Any client with publish rights
+  to `unas_fan_control/<id>/set/#` can retune the fan curve (within its safe
+  ranges — the `*_MAX` ceilings cannot be touched over MQTT, so it cannot
+  cause thermal runaway, but it can reduce cooling headroom). With mosquitto:
+
+  ```
+  # /etc/mosquitto/acl
+  user unas
+  topic write unas_fan_control/#
+  topic read homeassistant/status
+
+  user homeassistant
+  topic readwrite unas_fan_control/#
+  topic readwrite homeassistant/#
+  ```
+
+- **Credentials are sent unencrypted unless `MQTT_TLS=true`.** Fine on a
+  trusted LAN segment; enable TLS if the broker is reachable from guest/IoT
+  VLANs or anything you don't fully trust.
+- The state topic includes drive serial numbers; scope broker read access
+  accordingly, and run the uninstall's `--clear` step to remove retained
+  messages from the broker when decommissioning.
+
+## Implementation notes
+
+The bridge is a single-file, stdlib-only python3 daemon (`mqtt_bridge.py`)
+speaking MQTT 3.1.1 with username/password auth and optional TLS (certificate
+verification always on; point `MQTT_TLS_CA` at a self-signed broker cert). It
+deliberately avoids `paho-mqtt`/`mosquitto-clients` because UniFi OS firmware
+updates wipe apt-installed packages, while `/root` and `python3` survive.
+
+`fan_control.sh` itself stays MQTT-free: it calls hook functions provided by
+`fan_control_state.sh`, which writes an atomic JSON snapshot to
+`/run/fan_control/state.json` (root-only, tmpfs) that the bridge reads. The
+systemd unit caps the bridge at `MemoryMax=48M` / `CPUQuota=25%` / `Nice=10`,
+so even a misbehaving bridge cannot starve the NAS; a memory-cap kill is
+auto-restarted cleanly.
+
+Self-check: `python3 mqtt_bridge.py --selftest` runs offline packet/logic
+assertions and exits.
+
+## Troubleshooting
+
+```bash
+journalctl -u mqtt_bridge -f        # bridge logs (connects, commands, errors)
+cat /run/fan_control/state.json     # last snapshot written by fan_control.sh
+cat /run/fan_control/jq_error       # only exists if snapshot generation fails
+```
+
+## Uninstall
+
+```bash
+# 1. Stop the bridge FIRST (a running bridge would republish the discovery
+#    config right after it is cleared).
+systemctl disable --now mqtt_bridge.service
+
+# 2. Remove the device from Home Assistant (clears retained MQTT messages).
+/root/mqtt_bridge.py --clear
+
+# 3. Remove the files.
+rm -f /root/mqtt_bridge.py /root/mqtt_bridge.conf /root/mqtt_bridge.conf.example \
+      /root/fan_control_state.sh /root/fan_control.conf
+rm -f /etc/systemd/system/mqtt_bridge.service
+systemctl daemon-reload
+```
+
+Removing `/root/fan_control.conf` returns `fan_control.sh` to the defaults
+hardcoded at the top of the script.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ what state they were left in.
 
 </details>
 
+## MQTT / Home Assistant (Optional)
+
+An optional `mqtt_bridge` service publishes temperatures and fan speeds to an
+MQTT broker (e.g. mosquitto) with Home Assistant discovery, and lets you tune
+the fan curve's target temperatures from Home Assistant. It is fully opt-in
+(inactive without `/root/mqtt_bridge.conf`), and fan control never depends on
+it. See [MQTT.md](MQTT.md) for setup, entities, and uninstall.
+
 ## Algorithm Parameters
 
 Adjust the `fan_control.sh` parameters to suit your needs. These fan curves, specifically `MAX` and `TGT` temps, are currently set to keep the drives under 40ºC in a warm cabinet (30ºC ambient).

--- a/README.md
+++ b/README.md
@@ -190,12 +190,13 @@ it. See [MQTT.md](MQTT.md) for setup, entities, and uninstall.
 Adjust the `fan_control.sh` parameters to suit your needs. These fan curves, specifically `MAX` and `TGT` temps, are currently set to keep the drives under 40ºC in a warm cabinet (30ºC ambient).
 
 - `SYS_TGT=50`: The target system temp (hottest of the CPU die and board sensors) in celcius, at which fans will run at `MIN_FAN`.
-- `SYS_MAX=75`: The max system temp in celcius, where fans will run at 100%.
+- `SYS_MAX=85`: The max system temp in celcius, where fans will run at 100%.
 - `HDD_TGT=32`: The target HDD temp in celcius, at which fans will run at `MIN_FAN`.
-- `HDD_MAX=50`: The max HDD temp in celcius, where fans will run at 100%.
+- `HDD_MAX=55`: The max HDD temp in celcius, where fans will run at 100%.
 - `SSD_TGT=50`: The target SSD/NVMe temp in celcius, at which fans will run at `MIN_FAN`.
 - `SSD_MAX=70`: The max SSD/NVMe temp in celcius, where fans will run at 100%. Tuned for NVMe drives with little airflow, and safe for SATA SSDs too.
 - `MIN_FAN=39`: The minimum fan speed, 15% of 255 (fan speeds are out of 255).
+- `MAX_FAN=255`: The fan speed ceiling the curves ramp to at their MAX temps. Reduce to cap fan noise — note this caps the fans even when overheating. A value below `MIN_FAN` or above 255 is treated as invalid and the full range is used.
 
 Fan speed is set linearly between the TGT temp (`MIN_FAN` fan speed) and MAX temp (100% fan speed). All sensors and fans are auto-detected: system temperatures come from the SoC thermal zones (the CPU die) and the board sensors on the fan-controller chip, while drives are discovered via SMART and classified as HDD or SSD (both SATA SSDs and NVMe), each with their own fan curve. The hottest sensor within each class sets that class's temp, and the highest computed fan speed across the system, HDD, and SSD curves is used. Every PWM channel on each detected fan-controller chip is then driven (drive and PSU/PMBus chips are skipped, so a PSU/BMC-managed fan is never touched). Pseudocode and fan speed chart below.
 
@@ -215,8 +216,9 @@ SSD_RATIO = clip((SSD_TEMP - SSD_TGT) / (SSD_MAX - SSD_TGT), 0, 1)
 # The hottest sensor (relative to its own curve) wins.
 RATIO = max(SYS_RATIO, HDD_RATIO, SSD_RATIO)
 
-# Map 0..1 onto the fan range: MIN_FAN at the target, 100% at the max.
-FAN_SPEED = MIN_FAN + RATIO * (100% - MIN_FAN)
+# Map 0..1 onto the fan range: MIN_FAN at the target, MAX_FAN (default 100%)
+# at the max.
+FAN_SPEED = MIN_FAN + RATIO * (MAX_FAN - MIN_FAN)
 ```
 
 <details>

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,12 +12,19 @@ set -euo pipefail
 
 HOST="$1"
 
-scp fan_control.sh "${HOST}:/root/fan_control.sh"
-scp fan_control.service "${HOST}:/etc/systemd/system/fan_control.service"
+# The mqtt_bridge files are an optional MQTT/Home Assistant bridge, inert
+# until /root/mqtt_bridge.conf is created on the device (see MQTT.md).
+scp fan_control.sh fan_control_state.sh mqtt_bridge.py mqtt_bridge.conf.example "${HOST}:/root/"
+scp fan_control.service mqtt_bridge.service "${HOST}:/etc/systemd/system/"
 
+# The trailing status is informational only (|| true): mqtt_bridge.service is
+# intentionally inactive without a conf, and systemctl status exits non-zero
+# for inactive units; any real failure above still aborts via the && chain.
 ssh "$HOST" -t '\
-    chmod +x /root/fan_control.sh && \
+    chmod +x /root/fan_control.sh /root/mqtt_bridge.py && \
     systemctl daemon-reload && \
     systemctl enable fan_control.service && \
     systemctl restart fan_control.service && \
-    systemctl status fan_control.service'
+    systemctl enable mqtt_bridge.service && \
+    systemctl restart mqtt_bridge.service && \
+    { systemctl status fan_control.service mqtt_bridge.service || true; }'

--- a/fan_control.sh
+++ b/fan_control.sh
@@ -26,14 +26,18 @@ set -euo pipefail
 # sensors on the fan-controller chip (e.g. adt7475). The hottest of these drives
 # it. See get_system_temps() for how these sensors are discovered.
 SYS_TGT=50
-SYS_MAX=75
+# SYS_MAX 85: the SoC throttles ~85°C+, and the hottest board diode (adt7475
+# temp3) runs ~12°C above the CPU die at idle. A wider TGT..MAX span also
+# flattens the curve slope so small temp wobbles don't slam the fans around.
+SYS_MAX=85
 HDD_TGT=32
-HDD_MAX=50
+HDD_MAX=55
 # SSDs (SATA and NVMe) tolerate higher temperatures than spinning disks.
 # Tuned for NVMe drives, which often have little airflow; safe for SATA SSDs too.
 SSD_TGT=50
 SSD_MAX=70
 MIN_FAN=39  # 15% of 255 (increase baseline to reduce fan speed variation)
+MAX_FAN=255 # Fan speed ceiling (reduce to cap noise; caps the curve even when overheating)
 
 # Optional MQTT-bridge hooks (fan_control_state.sh): apply_fan_conf applies
 # validated fan-curve overrides tuned from Home Assistant, and the state_*
@@ -246,23 +250,27 @@ set_fan_speed() {
     done < <(get_disk_temps)
 
     # Function to calculate fan curve. The speed ramps linearly from MIN_FAN at
-    # the target temp (tgt) to 255 (100%) at the max temp, and is held at
-    # MIN_FAN below tgt. Scaling into [MIN_FAN, 255] means the fan starts
-    # responding right at tgt, rather than ignoring rising temps until a plain
-    # 0-based ramp happens to climb past the MIN_FAN floor.
+    # the target temp (tgt) to MAX_FAN (default 255 = 100%) at the max temp,
+    # and is held at MIN_FAN below tgt. Scaling into [MIN_FAN, MAX_FAN] means
+    # the fan starts responding right at tgt, rather than ignoring rising temps
+    # until a plain 0-based ramp happens to climb past the MIN_FAN floor.
     fan_curve() {
         local tgt=$1
         local actual=$2
         local max=$3
 
-        fan_speed=$(awk -v tgt="$tgt" -v actual="$actual" -v max="$max" -v floor="$MIN_FAN" '
+        fan_speed=$(awk -v tgt="$tgt" -v actual="$actual" -v max="$max" -v floor="$MIN_FAN" -v ceil="$MAX_FAN" '
         BEGIN {
             # Clamp the floor into the valid PWM range first. An absurdly
             # large floor (bad MIN_FAN edit) otherwise cancels catastrophically
-            # in floor + ratio * (255 - floor) and prints 0 -- commanding the
+            # in floor + ratio * (ceil - floor) and prints 0 -- commanding the
             # fans OFF precisely when overheating.
             if (floor < 0) floor = 0
             if (floor > 255) floor = 255
+            # Invalid ceiling (below the floor or above 255, e.g. bad MAX_FAN
+            # edit): fail hot with the full range rather than pinning the fans
+            # below the floor.
+            if (ceil < floor || ceil > 255) ceil = 255
             if (max <= tgt) {
                 # Degenerate/inverted parameters (TGT >= MAX): fail hot.
                 # Without this, actual <= tgt would swallow the whole range
@@ -277,7 +285,7 @@ set_fan_speed() {
             }
             if (ratio < 0) ratio = 0
             if (ratio > 1) ratio = 1
-            printf "%d", floor + ratio * (255 - floor)
+            printf "%d", floor + ratio * (ceil - floor)
         }')
         echo "$fan_speed"
     }
@@ -298,6 +306,7 @@ set_fan_speed() {
     log_echo "Max System Temperature: ${SYS_TEMP}°C"
 
     log_echo "Min Fan Speed: ${MIN_FAN}"
+    log_echo "Max Fan Speed: ${MAX_FAN}"
     log_echo "HDD Fan Speed: ${HDD_FAN}"
     log_echo "SSD Fan Speed: ${SSD_FAN}"
     log_echo "System Fan Speed: ${SYS_FAN}"

--- a/fan_control.sh
+++ b/fan_control.sh
@@ -35,6 +35,19 @@ SSD_TGT=50
 SSD_MAX=70
 MIN_FAN=39  # 15% of 255 (increase baseline to reduce fan speed variation)
 
+# Optional MQTT-bridge hooks (fan_control_state.sh): apply_fan_conf applies
+# validated fan-curve overrides tuned from Home Assistant, and the state_*
+# hooks snapshot readings for the bridge. The no-op stubs below are the
+# defaults; a missing or broken helper leaves them in place, so fan control
+# never depends on the helper or the MQTT bridge.
+apply_fan_conf() { :; }
+state_begin() { :; }
+state_add_drive() { :; }
+state_end() { :; }
+if [[ -f /root/fan_control_state.sh ]]; then
+    source /root/fan_control_state.sh 2>/dev/null || true
+fi
+
 usage() {
     cat <<'EOF'
 Usage: fan_control.sh [--service | --restore | -h | --help]
@@ -154,7 +167,7 @@ get_disk_temps() {
 
             ([current_from_top, current_from_nvme_fallback, current_from_ata_attr_fallback] | first(.[]?)) as $temp
             | select($temp != null)
-            | [(device_class), $dev, ($temp | tostring)] | @tsv
+            | [(device_class), $dev, ($temp | tostring), (.serial_number // "")] | @tsv
         ' <<< "$json" 2>/dev/null || true
     done < <(jq -r '.devices[]? | [.name, (.type // "")] | @tsv' <<< "$scan" 2>/dev/null)
 }
@@ -201,6 +214,11 @@ get_system_temps() {
 }
 
 set_fan_speed() {
+    # Apply Home Assistant/MQTT parameter overrides, and reset the state
+    # snapshot for this iteration (no-ops unless the MQTT bridge is set up).
+    apply_fan_conf
+    state_begin
+
     # Auto-discover all system temperature sensors (CPU die + board/airflow) and
     # track the hottest. See get_system_temps().
     SYS_TEMP=0
@@ -216,9 +234,10 @@ set_fan_speed() {
 
     # Auto-discover all SMART devices and read each one's temperature, tracking
     # the hottest HDD and the hottest SSD separately. See get_disk_temps().
-    while IFS=$'\t' read -r class dev temp; do
+    while IFS=$'\t' read -r class dev temp serial; do
         [[ "$temp" =~ ^-?[0-9]+$ ]] || continue
         log_echo "${dev} ${class} Temperature: ${temp}°C"
+        state_add_drive "$class" "$dev" "$temp" "$serial"
         if [[ "$class" == "SSD" ]]; then
             if [ "$temp" -gt "$SSD_TEMP" ]; then SSD_TEMP=$temp; fi
         else
@@ -344,6 +363,9 @@ set_fan_speed() {
         echo "No fan controller found (hwmon chip with pwm* outputs and fan*_input tachometers)."
         exit 1
     fi
+
+    # Write the state snapshot for the MQTT bridge (no-op unless installed).
+    state_end
 }
 
 # Hand the fans back to automatic (firmware/chip) control on every fan-controller

--- a/fan_control.sh
+++ b/fan_control.sh
@@ -238,7 +238,18 @@ set_fan_speed() {
 
         fan_speed=$(awk -v tgt="$tgt" -v actual="$actual" -v max="$max" -v floor="$MIN_FAN" '
         BEGIN {
-            if (actual <= tgt) {
+            # Clamp the floor into the valid PWM range first. An absurdly
+            # large floor (bad MIN_FAN edit) otherwise cancels catastrophically
+            # in floor + ratio * (255 - floor) and prints 0 -- commanding the
+            # fans OFF precisely when overheating.
+            if (floor < 0) floor = 0
+            if (floor > 255) floor = 255
+            if (max <= tgt) {
+                # Degenerate/inverted parameters (TGT >= MAX): fail hot.
+                # Without this, actual <= tgt would swallow the whole range
+                # and silently pin the fans at the minimum while overheating.
+                ratio = (actual > tgt) ? 1 : 0
+            } else if (actual <= tgt) {
                 ratio = 0
             } else if (actual >= max) {
                 ratio = 1
@@ -249,7 +260,7 @@ set_fan_speed() {
             if (ratio > 1) ratio = 1
             printf "%d", floor + ratio * (255 - floor)
         }')
-        echo $fan_speed
+        echo "$fan_speed"
     }
 
     # Calculate fan speeds

--- a/fan_control_state.sh
+++ b/fan_control_state.sh
@@ -43,7 +43,7 @@ apply_fan_conf() {
         case "$k" in
             SYS_TGT|SYS_MAX|HDD_TGT|HDD_MAX|SSD_TGT|SSD_MAX)
                 [[ "$v" =~ ^[0-9]{1,3}$ && $v -le 150 ]] && printf -v "$k" '%s' "$v" ;;
-            MIN_FAN)
+            MIN_FAN|MAX_FAN)
                 [[ "$v" =~ ^[0-9]{1,3}$ && $v -le 255 ]] && printf -v "$k" '%s' "$v" ;;
         esac
     done < "$FAN_CONF" 2>/dev/null || true
@@ -64,7 +64,7 @@ state_add_drive() {
 }
 
 # Write the snapshot. Reads fan_control.sh globals: SYS_TEMP HDD_TEMP SSD_TEMP
-# FAN_SPEED SYS_TGT SYS_MAX HDD_TGT HDD_MAX SSD_TGT SSD_MAX MIN_FAN.
+# FAN_SPEED SYS_TGT SYS_MAX HDD_TGT HDD_MAX SSD_TGT SSD_MAX MIN_FAN MAX_FAN.
 state_end() {
     (( ${STATE_ENABLED:-0} )) || return 0
     (
@@ -116,7 +116,8 @@ state_end() {
             --argjson sys_tgt "${SYS_TGT:-0}" --argjson sys_max "${SYS_MAX:-0}" \
             --argjson hdd_tgt "${HDD_TGT:-0}" --argjson hdd_max "${HDD_MAX:-0}" \
             --argjson ssd_tgt "${SSD_TGT:-0}" --argjson ssd_max "${SSD_MAX:-0}" \
-            --argjson min_fan "${MIN_FAN:-0}" '
+            --argjson min_fan "${MIN_FAN:-0}" \
+            --argjson max_fan "${MAX_FAN:-255}" '
             (split("\n") | map(select(length > 0) | split("\t"))) as $rows
             | ($rows | map(select(.[0] == "D"))) as $drows
             | {
@@ -140,7 +141,7 @@ state_end() {
                     sys_tgt: $sys_tgt, sys_max: $sys_max,
                     hdd_tgt: $hdd_tgt, hdd_max: $hdd_max,
                     ssd_tgt: $ssd_tgt, ssd_max: $ssd_max,
-                    min_fan: $min_fan
+                    min_fan: $min_fan, max_fan: $max_fan
                 }
             }' > "$STATE_FILE.tmp" 2>"$STATE_DIR/jq_error" \
             && rm -f "$STATE_DIR/jq_error" \

--- a/fan_control_state.sh
+++ b/fan_control_state.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Optional MQTT-bridge hooks for fan_control.sh.
+#
+# When installed at /root/fan_control_state.sh, fan_control.sh sources it and
+# calls apply_fan_conf / state_begin / state_add_drive / state_end on every
+# loop iteration, replacing the no-op stubs it defines otherwise. The hooks:
+#
+#   apply_fan_conf    apply fan-curve overrides tuned from Home Assistant
+#                     (written by mqtt_bridge.py to /root/fan_control.conf)
+#   state_*           write an atomic JSON snapshot of temperatures, fan
+#                     speeds, and tachometers to /run/fan_control/state.json
+#                     (tmpfs) for mqtt_bridge.py to publish
+#
+# The snapshot is only written when /root/mqtt_bridge.conf exists, so without
+# an MQTT setup this file adds a single file-existence check per loop.
+#
+# Failures here must never break fan control: the conf file is parsed against
+# a strict key allowlist (never sourced, so it cannot execute code or crash
+# the script), and state_end swallows all errors. jq errors are captured in
+# /run/fan_control/jq_error for diagnosis instead of being discarded.
+#
+# Repo: https://github.com/hoxxep/UNAS-Pro-fan-control
+# License: MIT
+
+FAN_CONF=/root/fan_control.conf
+BRIDGE_CONF=/root/mqtt_bridge.conf
+STATE_DIR=/run/fan_control
+STATE_FILE="$STATE_DIR/state.json"
+
+# Apply fan-curve overrides from FAN_CONF. Only whitelisted keys with plain
+# integer values in a sane range are accepted; anything else is ignored.
+# Range checks matter for safety, not just hygiene: an absurdly large MIN_FAN
+# reaching the awk fan curve causes float cancellation that computes a fan
+# speed of 0 while overheating. Oversized files are skipped outright.
+apply_fan_conf() {
+    local k v size
+    [[ -f "$FAN_CONF" ]] || return 0
+    size=$(wc -c < "$FAN_CONF" 2>/dev/null) || return 0
+    [[ "$size" =~ ^[[:space:]]*[0-9]+$ && $size -le 4096 ]] || return 0
+    while IFS='=' read -r k v; do
+        v="${v%$'\r'}"  # tolerate CRLF-edited files
+        case "$k" in
+            SYS_TGT|SYS_MAX|HDD_TGT|HDD_MAX|SSD_TGT|SSD_MAX)
+                [[ "$v" =~ ^[0-9]{1,3}$ && $v -le 150 ]] && printf -v "$k" '%s' "$v" ;;
+            MIN_FAN)
+                [[ "$v" =~ ^[0-9]{1,3}$ && $v -le 255 ]] && printf -v "$k" '%s' "$v" ;;
+        esac
+    done < "$FAN_CONF" 2>/dev/null || true
+    return 0
+}
+
+state_begin() {
+    STATE_DRIVES=()
+    STATE_ENABLED=0
+    [[ -f "$BRIDGE_CONF" ]] && STATE_ENABLED=1
+    return 0
+}
+
+# state_add_drive CLASS DEV TEMP SERIAL
+state_add_drive() {
+    STATE_DRIVES+=("$1"$'\t'"$2"$'\t'"$3"$'\t'"${4:-}")
+    return 0
+}
+
+# Write the snapshot. Reads fan_control.sh globals: SYS_TEMP HDD_TEMP SSD_TEMP
+# FAN_SPEED SYS_TGT SYS_MAX HDD_TGT HDD_MAX SSD_TGT SSD_MAX MIN_FAN.
+state_end() {
+    (( ${STATE_ENABLED:-0} )) || return 0
+    (
+        set +e
+        umask 077  # snapshot holds drive serials; keep it root-only
+        mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+        chmod 700 "$STATE_DIR" 2>/dev/null  # mkdir -p won't tighten a pre-existing dir
+
+        # Collect tachometers from the same fan-controller chips
+        # fan_control.sh drives (skip drive and PSU/PMBus chips). Keys are
+        # "<chipname>_fanN"; a second chip with the same driver name gets a
+        # "_2"/"_3" suffix so twin controllers cannot collide.
+        local rows=() row hw name f v key n seen=" "
+        for row in ${STATE_DRIVES[@]+"${STATE_DRIVES[@]}"}; do
+            rows+=("D"$'\t'"$row")
+        done
+        for hw in /sys/class/hwmon/hwmon*; do
+            [[ -e "$hw" ]] || continue
+            name="$(cat "$hw/name" 2>/dev/null || echo hwmon)"
+            case "$name" in
+                nvme|drivetemp) continue ;;
+                *pmbus*|*dps[0-9]*|*psu*) continue ;;
+            esac
+            for f in "$hw"/fan*_input; do
+                [[ -e "$f" ]] || continue
+                v="$(cat "$f" 2>/dev/null)"
+                [[ "$v" =~ ^[0-9]+$ ]] || continue
+                key="${name}_$(basename "${f%_input}")"
+                if [[ "$seen" == *" $key "* ]]; then
+                    n=2
+                    while [[ "$seen" == *" ${key}_$n "* ]]; do n=$(( n + 1 )); done
+                    key="${key}_$n"
+                fi
+                seen+="$key "
+                rows+=("T"$'\t'"$key"$'\t'"$v")
+            done
+        done
+
+        # Drive keys: serial number sanitized to [A-Za-z0-9_-] (stable across
+        # /dev renames, and safe to embed in Home Assistant templates), with
+        # the device basename as fallback when SMART reports no serial.
+        # hdd_temp/ssd_temp are null when no drive of that class exists, so
+        # the bridge can omit those sensors instead of reporting 0°C.
+        printf '%s\n' ${rows[@]+"${rows[@]}"} | jq -R -s \
+            --argjson sys_temp "${SYS_TEMP:-0}" \
+            --argjson hdd_temp "${HDD_TEMP:-0}" \
+            --argjson ssd_temp "${SSD_TEMP:-0}" \
+            --argjson fan_speed "${FAN_SPEED:-0}" \
+            --argjson sys_tgt "${SYS_TGT:-0}" --argjson sys_max "${SYS_MAX:-0}" \
+            --argjson hdd_tgt "${HDD_TGT:-0}" --argjson hdd_max "${HDD_MAX:-0}" \
+            --argjson ssd_tgt "${SSD_TGT:-0}" --argjson ssd_max "${SSD_MAX:-0}" \
+            --argjson min_fan "${MIN_FAN:-0}" '
+            (split("\n") | map(select(length > 0) | split("\t"))) as $rows
+            | ($rows | map(select(.[0] == "D"))) as $drows
+            | {
+                ts: (now | floor),
+                sys_temp: $sys_temp,
+                hdd_temp: (if ($drows | map(select(.[1] == "HDD")) | length) == 0
+                           then null else $hdd_temp end),
+                ssd_temp: (if ($drows | map(select(.[1] == "SSD")) | length) == 0
+                           then null else $ssd_temp end),
+                fan_speed_raw: $fan_speed,
+                fan_duty_pct: (($fan_speed * 100 / 255) + 0.5 | floor),
+                drives: ($drows | map({
+                    key: ((if (.[4] // "") != "" then .[4]
+                           else (.[2] | sub(".*/"; "")) end)
+                          | gsub("[^A-Za-z0-9_-]"; "_")),
+                    value: {class: .[1], dev: .[2], temp: (.[3] | tonumber)}
+                }) | from_entries),
+                tachs: ($rows | map(select(.[0] == "T")
+                    | {key: .[1], value: (.[2] | tonumber)}) | from_entries),
+                params: {
+                    sys_tgt: $sys_tgt, sys_max: $sys_max,
+                    hdd_tgt: $hdd_tgt, hdd_max: $hdd_max,
+                    ssd_tgt: $ssd_tgt, ssd_max: $ssd_max,
+                    min_fan: $min_fan
+                }
+            }' > "$STATE_FILE.tmp" 2>"$STATE_DIR/jq_error" \
+            && rm -f "$STATE_DIR/jq_error" \
+            && mv "$STATE_FILE.tmp" "$STATE_FILE"
+        exit 0
+    ) || true
+}

--- a/mqtt_bridge.conf.example
+++ b/mqtt_bridge.conf.example
@@ -1,0 +1,34 @@
+# MQTT bridge configuration for UNAS-Pro-fan-control.
+#
+# Copy to /root/mqtt_bridge.conf, edit, then: systemctl restart mqtt_bridge
+# The mqtt_bridge service only runs when /root/mqtt_bridge.conf exists.
+# Keep it private (chmod 600) -- it contains the broker password.
+
+# Broker address (required). For Home Assistant's Mosquitto add-on this is the
+# Home Assistant host.
+MQTT_HOST=192.168.1.10
+MQTT_PORT=1883
+
+# Broker credentials. Create a dedicated user on the broker, e.g.:
+#   mosquitto_passwd /etc/mosquitto/passwd unas
+# Quote the value if it contains a '#' character.
+MQTT_USER=unas
+MQTT_PASS=secret
+
+# Optional TLS. Certificate verification is always on; for a self-signed
+# broker certificate, point MQTT_TLS_CA at the CA (or server) cert file.
+#MQTT_TLS=true
+#MQTT_TLS_CA=/root/mqtt_ca.crt
+
+# Optional overrides. Device ID defaults to the hostname; it becomes part of
+# the MQTT topics and the Home Assistant device identity, so pick something
+# stable — and UNIQUE per device if several UNAS units share one broker.
+# Discovery prefix must match the Home Assistant MQTT integration setting
+# (default: homeassistant).
+#MQTT_DEVICE_ID=unas-pro
+#MQTT_DISCOVERY_PREFIX=homeassistant
+
+# "Visit" link on the Home Assistant device page.
+# Defaults to https://<LAN IP facing the broker>; https:// is prepended if
+# no scheme given.
+#MQTT_DEVICE_URL=https://192.168.1.20

--- a/mqtt_bridge.py
+++ b/mqtt_bridge.py
@@ -1,0 +1,727 @@
+#!/usr/bin/python3
+"""MQTT bridge for UNAS-Pro-fan-control.
+
+Publishes the sensor snapshot written by fan_control.sh (via
+fan_control_state.sh) to an MQTT broker with Home Assistant device-based
+discovery, and lets Home Assistant tune the fan-curve target temperatures by
+writing /root/fan_control.conf (sourced by fan_control.sh every loop).
+
+Design constraints (see README):
+- stdlib only: UniFi OS firmware updates wipe apt packages, but /root and
+  python3 survive. So this file hand-rolls a minimal MQTT 3.1.1 client
+  (CONNECT with auth + LWT, PUBLISH QoS 0, SUBSCRIBE, PINGREQ) instead of
+  depending on paho-mqtt or mosquitto-clients.
+- Fan safety is never in this process: fan_control.sh runs its own loop and
+  only reads the curve parameters from a conf file. If this bridge dies, fans
+  keep working.
+
+Usage:
+  mqtt_bridge.py             run the bridge (needs /root/mqtt_bridge.conf)
+  mqtt_bridge.py --clear     remove the device from Home Assistant (publishes
+                             an empty retained discovery config) and exit
+  mqtt_bridge.py --selftest  run offline packet/logic self-checks and exit
+
+Repo: https://github.com/hoxxep/UNAS-Pro-fan-control
+License: MIT
+"""
+
+import hashlib
+import json
+import math
+import os
+import re
+import select
+import signal
+import socket
+import ssl
+import struct
+import sys
+import time
+
+VERSION = "1.0.0"
+
+BRIDGE_CONF = os.environ.get("MQTT_BRIDGE_CONF", "/root/mqtt_bridge.conf")
+FAN_CONF = os.environ.get("FAN_CONF", "/root/fan_control.conf")
+STATE_FILE = os.environ.get("FAN_STATE_FILE", "/run/fan_control/state.json")
+KEEPALIVE = 60
+STATE_EXPIRE_AFTER = 180  # seconds; ~3x the 60s fan_control loop
+MAX_PACKET = 1 << 20  # sanity cap on inbound packets; guards memory spikes
+CONF_WRITE_INTERVAL = 2.0  # min seconds between conf writes (flood/flash-wear guard)
+
+# Hard ceilings for values (re)written to fan_control.conf, matching the
+# allowlist ranges fan_control_state.sh enforces on read. Values a hand-edit
+# or bug put outside these are dropped rather than perpetuated.
+CONF_KEY_MAX = {"SYS_TGT": 150, "SYS_MAX": 150, "HDD_TGT": 150, "HDD_MAX": 150,
+                "SSD_TGT": 150, "SSD_MAX": 150, "MIN_FAN": 255}
+
+# Curve parameters exposed as Home Assistant number entities. Ranges are hard
+# caps chosen to sit below the fixed *_MAX ceilings in fan_control.sh, so a
+# slider can never invert the curve (TGT >= MAX). MIN_FAN is exposed as a
+# percentage but stored raw (0-255) in the conf, matching fan_control.sh.
+PARAMS = {
+    "sys_tgt": {"conf_key": "SYS_TGT", "name": "System target temp", "min": 35, "max": 65, "unit": "°C"},
+    "hdd_tgt": {"conf_key": "HDD_TGT", "name": "HDD target temp", "min": 25, "max": 45, "unit": "°C"},
+    "ssd_tgt": {"conf_key": "SSD_TGT", "name": "SSD target temp", "min": 35, "max": 62, "unit": "°C"},
+    "min_fan_pct": {"conf_key": "MIN_FAN", "name": "Minimum fan speed", "min": 10, "max": 100, "unit": "%"},
+}
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Minimal MQTT 3.1.1 encoding/decoding
+# ---------------------------------------------------------------------------
+
+def encode_varint(n):
+    out = bytearray()
+    while True:
+        byte = n % 128
+        n //= 128
+        out.append(byte | 0x80 if n else byte)
+        if not n:
+            return bytes(out)
+
+
+def encode_str(s):
+    b = s.encode("utf-8")
+    return struct.pack(">H", len(b)) + b
+
+
+def connect_packet(client_id, username, password, will_topic, will_payload):
+    flags = 0x02  # clean session
+    payload = encode_str(client_id)
+    if will_topic:
+        flags |= 0x04 | 0x20  # will flag + will retain, QoS 0
+        payload += encode_str(will_topic) + encode_str(will_payload)
+    if username:
+        flags |= 0x80
+        payload += encode_str(username)
+        if password is not None:
+            flags |= 0x40
+            payload += encode_str(password)
+    var = encode_str("MQTT") + bytes([4, flags]) + struct.pack(">H", KEEPALIVE)
+    body = var + payload
+    return bytes([0x10]) + encode_varint(len(body)) + body
+
+
+def publish_packet(topic, payload, retain=False):
+    if isinstance(payload, str):
+        payload = payload.encode("utf-8")
+    body = encode_str(topic) + payload
+    return bytes([0x30 | (0x01 if retain else 0x00)]) + encode_varint(len(body)) + body
+
+
+def subscribe_packet(packet_id, topics):
+    body = struct.pack(">H", packet_id)
+    for t in topics:
+        body += encode_str(t) + b"\x00"  # QoS 0
+    return bytes([0x82]) + encode_varint(len(body)) + body
+
+
+PINGREQ = bytes([0xC0, 0x00])
+DISCONNECT = bytes([0xE0, 0x00])
+
+
+def parse_publish(flags, body):
+    """Parse an incoming PUBLISH body -> (topic, payload)."""
+    if len(body) < 2:
+        raise ConnectionError("malformed PUBLISH")
+    tlen = struct.unpack(">H", body[:2])[0]
+    topic = body[2:2 + tlen].decode("utf-8", "replace")
+    pos = 2 + tlen
+    if (flags >> 1) & 0x03:  # QoS > 0 carries a packet id (we subscribe QoS 0)
+        pos += 2
+    return topic, body[pos:]
+
+
+class MqttClient:
+    """Blocking-socket MQTT 3.1.1 client, QoS 0 only."""
+
+    def __init__(self, conf):
+        self.conf = conf
+        self.sock = None
+        self.last_send = 0.0
+        self.on_message = None
+
+    def connect(self, will_topic, will_payload):
+        raw = socket.create_connection((self.conf["host"], self.conf["port"]), timeout=15)
+        if self.conf["tls"]:
+            # Certificate verification is always on. For a self-signed broker
+            # cert, point MQTT_TLS_CA at the CA/cert file instead.
+            ctx = ssl.create_default_context(cafile=self.conf["tls_ca"] or None)
+            raw = ctx.wrap_socket(raw, server_hostname=self.conf["host"])
+        self.sock = raw
+        self.sock.settimeout(15)
+        self._send(connect_packet(self.conf["client_id"], self.conf["user"],
+                                  self.conf["password"], will_topic, will_payload))
+        ptype, _, body = self._read_packet()
+        if ptype != 0x20 or len(body) < 2 or body[1] != 0:
+            rc = body[1] if len(body) >= 2 else -1
+            raise ConnectionError("CONNACK refused (return code %d; 4/5 = bad credentials)" % rc)
+
+    def subscribe(self, topics):
+        self._send(subscribe_packet(1, topics))
+        # SUBACK may arrive after queued retained PUBLISHes on some brokers;
+        # accept both until the SUBACK shows up.
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            ptype, flags, body = self._read_packet()
+            if ptype == 0x90:
+                if any(rc == 0x80 for rc in body[2:]):
+                    raise ConnectionError("SUBACK reported failure")
+                return
+            self._dispatch(ptype, flags, body)
+        raise ConnectionError("no SUBACK")
+
+    def publish(self, topic, payload, retain=False):
+        self._send(publish_packet(topic, payload, retain))
+
+    def loop(self, timeout):
+        """Process incoming packets for up to `timeout` seconds; keepalive."""
+        # select() cannot see data already decrypted into the SSL layer's
+        # buffer, so check pending() first and drain after each read.
+        if self._pending() or select.select([self.sock], [], [], timeout)[0]:
+            self._dispatch(*self._read_packet())
+            while self._pending():
+                self._dispatch(*self._read_packet())
+        if time.monotonic() - self.last_send > KEEPALIVE / 2:
+            self._send(PINGREQ)
+
+    def _pending(self):
+        return isinstance(self.sock, ssl.SSLSocket) and self.sock.pending() > 0
+
+    def close(self):
+        if self.sock is not None:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+            self.sock = None
+
+    def disconnect(self):
+        try:
+            self._send(DISCONNECT)
+        except OSError:
+            pass
+        self.close()
+
+    def _dispatch(self, ptype, flags, body):
+        if ptype == 0x30 and self.on_message:
+            topic, payload = parse_publish(flags, body)
+            self.on_message(topic, payload)
+        # PINGRESP (0xD0) and anything else: nothing to do at QoS 0.
+
+    def _send(self, data):
+        self.sock.sendall(data)
+        self.last_send = time.monotonic()
+
+    def _recv_exact(self, n):
+        buf = b""
+        while len(buf) < n:
+            chunk = self.sock.recv(n - len(buf))
+            if not chunk:
+                raise ConnectionError("socket closed")
+            buf += chunk
+        return buf
+
+    def _read_packet(self):
+        first = self._recv_exact(1)[0]
+        remaining, mult = 0, 1
+        for _ in range(4):
+            byte = self._recv_exact(1)[0]
+            remaining += (byte & 0x7F) * mult
+            if not byte & 0x80:
+                break
+            mult *= 128
+        else:
+            raise ConnectionError("bad varint")
+        if remaining > MAX_PACKET:
+            raise ConnectionError("packet too large (%d bytes)" % remaining)
+        body = self._recv_exact(remaining) if remaining else b""
+        return first & 0xF0, first & 0x0F, body
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def parse_conf_file(path):
+    """Parse a KEY=value file (full-line and inline comments, optional quotes).
+
+    Values containing a literal '#' must be quoted.
+    """
+    conf = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            else:
+                value = value.split("#", 1)[0].strip()
+            conf[key.strip()] = value
+    return conf
+
+
+def sanitize_id(s):
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", s)
+
+
+def load_bridge_conf(path):
+    # The conf holds the broker password: enforce root-only permissions
+    # rather than trusting the documented manual chmod to have happened.
+    try:
+        if os.stat(path).st_mode & 0o077:
+            os.chmod(path, 0o600)
+            log("Tightened %s permissions to 600 (it holds MQTT_PASS)" % path)
+    except OSError:
+        pass
+    raw = parse_conf_file(path)
+    if "MQTT_HOST" not in raw:
+        sys.exit("MQTT_HOST missing from %s" % path)
+    try:
+        port = int(raw.get("MQTT_PORT", "1883"))
+    except ValueError:
+        sys.exit("MQTT_PORT in %s is not a number: %r" % (path, raw.get("MQTT_PORT")))
+    if raw.get("MQTT_PASS") and not raw.get("MQTT_USER"):
+        sys.exit("MQTT_PASS is set but MQTT_USER is missing in %s -- MQTT "
+                 "cannot send a password without a username." % path)
+    device_id = sanitize_id(raw.get("MQTT_DEVICE_ID") or socket.gethostname().split(".")[0].lower())
+    # "Visit" link on the HA device page. Default to the LAN IP facing the
+    # broker (hostnames often don't resolve from the HA client's browser);
+    # a UDP connect() picks the outbound interface without sending packets.
+    # HA rejects a discovery payload whose configuration_url has no scheme,
+    # so force one rather than fail silently.
+    device_url = raw.get("MQTT_DEVICE_URL")
+    if not device_url:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.connect((raw["MQTT_HOST"], port))
+                device_url = "https://" + s.getsockname()[0]
+        except OSError:
+            device_url = "https://" + socket.gethostname()
+    if not re.match(r"^https?://", device_url):
+        device_url = "https://" + device_url
+    prefix = raw.get("MQTT_DISCOVERY_PREFIX", "homeassistant")
+    if not 0 < len(device_id) <= 64 or not 0 < len(prefix) <= 64:
+        sys.exit("MQTT_DEVICE_ID / MQTT_DISCOVERY_PREFIX must be 1-64 characters.")
+    return {
+        "host": raw["MQTT_HOST"],
+        "port": port,
+        "user": raw.get("MQTT_USER") or None,
+        "password": raw.get("MQTT_PASS"),
+        "tls": raw.get("MQTT_TLS", "").lower() in ("1", "true", "yes"),
+        "tls_ca": raw.get("MQTT_TLS_CA", ""),
+        "device_id": device_id,
+        "device_url": device_url,
+        # 23 bytes (broker-safe): 7-char prefix + 8-char hash of the full
+        # device_id (so long ids that share a prefix cannot collide) + 7 chars
+        # of the id for readability.
+        "client_id": "unasfc-" + hashlib.sha1(device_id.encode()).hexdigest()[:8]
+                     + "-" + device_id[:7],
+        "discovery_prefix": prefix,
+    }
+
+
+def write_fan_conf(params_raw):
+    """Atomically (re)write the fan_control.sh override conf. Owns the file."""
+    lines = [
+        "# Written by mqtt_bridge.py -- fan-curve overrides tuned from Home Assistant.",
+        "# Sourced by fan_control.sh on every loop iteration. Deleting this file",
+        "# returns fan_control.sh to the defaults hardcoded at the top of the script.",
+    ] + ["%s=%d" % (k, v) for k, v in sorted(params_raw.items())]
+    tmp = FAN_CONF + ".tmp"
+    with open(tmp, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    os.replace(tmp, FAN_CONF)
+
+
+def clamp(value, lo, hi):
+    return max(lo, min(hi, value))
+
+
+def pct_to_raw(pct):
+    # ceil, not round: makes the HA display template (round(raw*100/255))
+    # a stable round-trip (39 -> 15% -> 39, not 38), and errs toward more
+    # cooling, never less.
+    return math.ceil(pct * 255 / 100)
+
+
+# ---------------------------------------------------------------------------
+# Home Assistant discovery
+# ---------------------------------------------------------------------------
+
+def topics(conf):
+    base = "unas_fan_control/" + conf["device_id"]
+    return {
+        "state": base + "/state",
+        "availability": base + "/availability",
+        "command": base + "/set/",  # + param key
+        "discovery": "%s/device/%s/config" % (conf["discovery_prefix"], conf["device_id"]),
+    }
+
+
+def discovery_payload(conf, state):
+    t = topics(conf)
+    uid = conf["device_id"]
+
+    def sensor(key, name, template, unit, device_class=None):
+        c = {
+            "p": "sensor",
+            "name": name,
+            "unique_id": "%s_%s" % (uid, key),
+            "value_template": template,
+            "unit_of_measurement": unit,
+            "state_class": "measurement",
+            "expire_after": STATE_EXPIRE_AFTER,
+            # Without this HA renders long-term-statistics float noise
+            # (36.999999...) on chart axes; one decimal keeps the 37,1 style.
+            "suggested_display_precision": 1,
+        }
+        if device_class:
+            c["device_class"] = device_class
+        return c
+
+    cmps = {
+        "sys_temp": sensor("sys_temp", "System temperature",
+                           "{{ value_json.sys_temp }}", "°C", "temperature"),
+        "fan_duty": sensor("fan_duty", "Fan duty",
+                           "{{ value_json.fan_duty_pct }}", "%"),
+    }
+    # hdd_temp/ssd_temp are null in the snapshot when no drive of that class
+    # exists; omit the sensor rather than report a misleading 0°C.
+    for key, name in (("hdd_temp", "HDD temperature (max)"),
+                      ("ssd_temp", "SSD temperature (max)")):
+        if state.get(key) is not None:
+            cmps[key] = sensor(key, name,
+                               "{{ value_json.%s }}" % key, "°C", "temperature")
+    # Drive/tach keys are pre-sanitized to [A-Za-z0-9_-] by
+    # fan_control_state.sh, so they are safe inside the Jinja templates.
+    for serial in sorted(state.get("drives", {})):
+        d = state["drives"][serial]
+        key = "drive_" + serial
+        name = "%s %s temperature" % (d.get("class", "Drive"), os.path.basename(d.get("dev", serial)))
+        cmps[key] = sensor(key, name,
+                           "{{ value_json.drives['%s'].temp }}" % serial, "°C", "temperature")
+    for tach in sorted(state.get("tachs", {})):
+        key = "tach_" + tach
+        cmps[key] = sensor(key, "Fan %s" % tach,
+                           "{{ value_json.tachs['%s'] }}" % tach, "rpm")
+
+    for pkey, spec in PARAMS.items():
+        template = ("{{ (value_json.params.min_fan * 100 / 255) | round(0) }}"
+                    if pkey == "min_fan_pct"
+                    else "{{ value_json.params.%s }}" % pkey)
+        cmps[pkey] = {
+            "p": "number",
+            "name": spec["name"],
+            "unique_id": "%s_%s" % (uid, pkey),
+            "command_topic": t["command"] + pkey,
+            "value_template": template,
+            "min": spec["min"],
+            "max": spec["max"],
+            "step": 1,
+            "mode": "slider",
+            "unit_of_measurement": spec["unit"],
+            "entity_category": "config",
+        }
+
+    return {
+        "dev": {
+            "ids": [uid],
+            "name": "UNAS Fan Control",
+            "mf": "Ubiquiti",
+            "sw": VERSION,
+            # ponytail: model/hw fields double as user-facing notes; HA has no
+            # free-text entity in MQTT discovery, and only one clickable link
+            # (configuration_url, used for the host). model_id would render
+            # inline as "model (model_id)"; hw_version gets its own line.
+            "mdl": "Settings apply within 60 s",
+            "hw": "github.com/hoxxep/UNAS-Pro-fan-control",
+            "cu": conf["device_url"],
+        },
+        "o": {
+            "name": "unas-fan-control",
+            "sw": VERSION,
+            "url": "https://github.com/hoxxep/UNAS-Pro-fan-control",
+        },
+        "cmps": cmps,
+        "state_topic": t["state"],
+        "availability_topic": t["availability"],
+    }
+
+
+def discovery_signature(state):
+    """Set of dynamic components; discovery is republished when it changes."""
+    return (tuple(sorted(state.get("drives", {}))),
+            tuple(sorted(state.get("tachs", {}))),
+            tuple(k for k in ("hdd_temp", "ssd_temp") if state.get(k) is not None))
+
+
+# ---------------------------------------------------------------------------
+# Bridge
+# ---------------------------------------------------------------------------
+
+class Bridge:
+    def __init__(self, conf):
+        self.conf = conf
+        self.topics = topics(conf)
+        self.state = None
+        self.state_mtime = 0.0
+        self.signature = None
+        self.client = None
+        self.online = False
+        self.backoff = 5
+        self.last_conf_write = float("-inf")
+
+    def run(self):
+        while True:
+            try:
+                self.connect_and_loop()
+            except (OSError, ConnectionError, struct.error) as e:
+                log("MQTT connection lost: %s -- reconnecting in %ds" % (e, self.backoff))
+            finally:
+                if self.client:
+                    self.client.close()
+            time.sleep(self.backoff)
+            self.backoff = min(self.backoff * 2, 60)
+
+    def connect_and_loop(self):
+        self.client = MqttClient(self.conf)
+        self.client.on_message = self.handle_message
+        self.client.connect(self.topics["availability"], "offline")
+        log("Connected to %s:%d as %s" % (self.conf["host"], self.conf["port"], self.conf["client_id"]))
+        self.client.subscribe(["homeassistant/status", self.topics["command"] + "+"])
+        self.backoff = 5
+        self.set_online(True)
+        # Republish immediately with the cached snapshot (if any) -- do not
+        # wait for the state file to change, the broker may have lost the
+        # retained discovery config while we were away.
+        self.signature = None
+        if self.state is not None:
+            self.publish_discovery_if_changed()
+            self.publish_state()
+        while True:
+            self.check_state_file()
+            self.client.loop(2.0)
+
+    def set_online(self, online):
+        """Availability tracks both the MQTT link and snapshot freshness."""
+        if online != self.online:
+            self.client.publish(self.topics["availability"],
+                                "online" if online else "offline", retain=True)
+            self.online = online
+            if not online:
+                log("State snapshot stale/missing -- marked unavailable")
+
+    def check_state_file(self):
+        try:
+            mtime = os.stat(STATE_FILE).st_mtime
+        except OSError:
+            self.set_online(False)  # fan_control.sh isn't writing snapshots
+            return
+        if mtime == self.state_mtime:
+            if time.time() - mtime > STATE_EXPIRE_AFTER:
+                self.set_online(False)  # fan_control.sh stopped updating
+            return
+        try:
+            with open(STATE_FILE) as f:
+                state = json.load(f)
+        except (OSError, ValueError) as e:
+            log("Bad state file: %s" % e)
+            return
+        self.state_mtime = mtime
+        self.state = state
+        self.set_online(True)
+        self.publish_discovery_if_changed()
+        self.publish_state()
+
+    def publish_discovery_if_changed(self):
+        sig = discovery_signature(self.state)
+        if sig == self.signature:
+            return
+        payload = json.dumps(discovery_payload(self.conf, self.state))
+        self.client.publish(self.topics["discovery"], payload, retain=True)
+        self.signature = sig
+        log("Published discovery (%d drives, %d tachs)"
+            % (len(self.state.get("drives", {})), len(self.state.get("tachs", {}))))
+
+    def publish_state(self):
+        if self.state is not None:
+            self.client.publish(self.topics["state"], json.dumps(self.state))
+
+    def handle_message(self, topic, payload):
+        payload = payload.decode("utf-8", "replace").strip()
+        if topic == "homeassistant/status":
+            if payload == "online" and self.state is not None:
+                log("Home Assistant birth message -- republishing")
+                self.signature = None
+                self.publish_discovery_if_changed()
+                self.client.publish(self.topics["availability"],
+                                    "online" if self.online else "offline", retain=True)
+                self.publish_state()
+        elif topic.startswith(self.topics["command"]):
+            self.handle_command(topic[len(self.topics["command"]):], payload)
+
+    def handle_command(self, pkey, payload):
+        spec = PARAMS.get(pkey)
+        if not spec:
+            log("Unknown parameter command: %r" % pkey)  # repr: no log injection
+            return
+        try:
+            value = float(payload)
+        except ValueError:
+            log("Ignoring non-numeric %s command: %r" % (pkey, payload))
+            return
+        if not math.isfinite(value):
+            log("Ignoring non-finite %s command: %r" % (pkey, payload))
+            return
+        value = clamp(round(value), spec["min"], spec["max"])
+        conf_value = pct_to_raw(value) if pkey == "min_fan_pct" else value
+        state_key = "min_fan" if pkey == "min_fan_pct" else pkey
+        # The conf file is the source of truth for persisted overrides: merge
+        # into whatever is already there (including hand-added keys), never
+        # rebuild from possibly-empty in-memory state.
+        try:
+            current = parse_conf_file(FAN_CONF) if os.path.exists(FAN_CONF) else {}
+        except OSError:
+            current = {}
+        merged = {k: int(v) for k, v in current.items()
+                  if k in CONF_KEY_MAX and v.isdigit() and int(v) <= CONF_KEY_MAX[k]}
+        if merged.get(spec["conf_key"]) == conf_value:
+            return  # unchanged (e.g. slider drag noise) -- skip the write
+        now = time.monotonic()
+        if now - self.last_conf_write < CONF_WRITE_INTERVAL:
+            log("Ignoring %s command: conf writes rate-limited" % pkey)
+            return
+        merged[spec["conf_key"]] = conf_value
+        try:
+            write_fan_conf(merged)
+        except OSError as e:
+            log("Failed to write %s: %s" % (FAN_CONF, e))
+            return
+        self.last_conf_write = now
+        log("Set %s=%s (conf updated; fan_control picks it up within 60s)" % (pkey, value))
+        # Optimistically patch the cached state so the HA slider doesn't snap
+        # back while waiting for the next fan_control loop iteration.
+        if self.state is not None:
+            self.state.setdefault("params", {})[state_key] = conf_value
+            self.publish_state()
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+def clear(conf):
+    """Remove the device from Home Assistant and exit.
+
+    Stop mqtt_bridge.service first: a running bridge would republish the
+    discovery config on its next reconnect, undoing the clear.
+    """
+    # Distinct client_id so this one-shot connection cannot take over (and
+    # kill) the daemon's broker session.
+    client = MqttClient(dict(conf, client_id=("c" + conf["client_id"])[:23]))
+    client.connect(None, None)
+    t = topics(conf)
+    client.publish(t["discovery"], b"", retain=True)  # empty retained = remove
+    client.publish(t["availability"], b"", retain=True)
+    client.disconnect()
+    log("Cleared retained discovery config for device '%s'" % conf["device_id"])
+
+
+def selftest():
+    # varint
+    assert encode_varint(0) == b"\x00"
+    assert encode_varint(127) == b"\x7f"
+    assert encode_varint(128) == b"\x80\x01"
+    assert encode_varint(16383) == b"\xff\x7f"
+    assert encode_varint(2097152) == b"\x80\x80\x80\x01"
+    # CONNECT golden packet (no auth, no will)
+    pkt = connect_packet("cid", None, None, None, None)
+    assert pkt == bytes([0x10, 15]) + b"\x00\x04MQTT\x04\x02\x00" + bytes([KEEPALIVE]) + b"\x00\x03cid"
+    # CONNECT with auth + will sets the right flags
+    pkt = connect_packet("c", "u", "p", "t", "offline")
+    assert pkt[9] == 0x02 | 0x04 | 0x20 | 0x80 | 0x40
+    # PUBLISH roundtrip
+    pkt = publish_packet("a/b", b"hi", retain=True)
+    assert pkt[0] == 0x31
+    topic, payload = parse_publish(0x01, pkt[2:])
+    assert (topic, payload) == ("a/b", b"hi")
+    # malformed PUBLISH raises ConnectionError, not struct.error
+    try:
+        parse_publish(0x00, b"\x00")
+        raise AssertionError("short PUBLISH must raise")
+    except ConnectionError:
+        pass
+    # SUBSCRIBE
+    pkt = subscribe_packet(1, ["x/+"])
+    assert pkt[0] == 0x82 and pkt.endswith(b"\x00\x03x/+\x00")
+    # conf parsing (inline comments stripped unless value is quoted)
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".conf", delete=False) as f:
+        f.write('# comment\nMQTT_HOST="broker.local"\nMQTT_PORT=1884  # default\n'
+                'MQTT_USER=u\nMQTT_PASS="se#ret"\n')
+        path = f.name
+    raw = parse_conf_file(path)
+    assert raw == {"MQTT_HOST": "broker.local", "MQTT_PORT": "1884",
+                   "MQTT_USER": "u", "MQTT_PASS": "se#ret"}
+    os.unlink(path)
+    # clamping and MIN_FAN conversion; ceil keeps the HA display template
+    # ({{ (raw * 100 / 255) | round(0) }}) a stable round-trip.
+    assert clamp(200, 25, 45) == 45 and clamp(-5, 25, 45) == 25
+    assert pct_to_raw(100) == 255 and pct_to_raw(10) == 26
+    for pct in range(10, 101):
+        # resubmitting the displayed percentage must not change the raw value
+        assert round(pct_to_raw(pct) * 100 / 255) == pct, pct
+    assert pct_to_raw(round(39 * 100 / 255)) == 39  # the default MIN_FAN
+    assert sanitize_id("WD-WX/1 2") == "WD-WX_1_2"
+    # discovery payload sanity
+    conf = {"device_id": "unas", "discovery_prefix": "homeassistant"}
+    state = {"sys_temp": 50, "hdd_temp": 34, "ssd_temp": None, "fan_duty_pct": 25,
+             "drives": {"WD1": {"class": "HDD", "dev": "/dev/sda", "temp": 34}},
+             "tachs": {"adt7475_fan1": 3170},
+             "params": {"sys_tgt": 50, "hdd_tgt": 32, "ssd_tgt": 50, "min_fan": 39}}
+    d = discovery_payload(conf, state)
+    assert d["dev"]["ids"] == ["unas"] and "o" in d
+    assert d["cmps"]["drive_WD1"]["value_template"] == "{{ value_json.drives['WD1'].temp }}"
+    assert d["cmps"]["hdd_tgt"]["p"] == "number" and d["cmps"]["hdd_tgt"]["max"] == 45
+    assert d["cmps"]["tach_adt7475_fan1"]["unit_of_measurement"] == "rpm"
+    assert "hdd_temp" in d["cmps"] and "ssd_temp" not in d["cmps"]  # null class omitted
+    assert all("unique_id" in c for c in d["cmps"].values())
+    json.dumps(d)  # must serialize
+    assert discovery_signature(state) == (("WD1",), ("adt7475_fan1",), ("hdd_temp",))
+    print("selftest OK")
+
+
+def main():
+    if "--selftest" in sys.argv:
+        selftest()
+        return
+    if not os.path.exists(BRIDGE_CONF):
+        sys.exit("Missing %s -- copy mqtt_bridge.conf.example and edit it." % BRIDGE_CONF)
+    conf = load_bridge_conf(BRIDGE_CONF)
+    if "--clear" in sys.argv:
+        clear(conf)
+        return
+
+    bridge = Bridge(conf)
+
+    def on_term(signum, frame):
+        # Just exit: closing the socket without DISCONNECT makes the broker
+        # fire our retained LWT ("offline"), which is exactly the state we
+        # want -- and keeps the handler safe to run mid-sendall.
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, on_term)
+    signal.signal(signal.SIGINT, on_term)
+    bridge.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mqtt_bridge.py
+++ b/mqtt_bridge.py
@@ -38,7 +38,7 @@ import struct
 import sys
 import time
 
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 BRIDGE_CONF = os.environ.get("MQTT_BRIDGE_CONF", "/root/mqtt_bridge.conf")
 FAN_CONF = os.environ.get("FAN_CONF", "/root/fan_control.conf")
@@ -52,17 +52,20 @@ CONF_WRITE_INTERVAL = 2.0  # min seconds between conf writes (flood/flash-wear g
 # allowlist ranges fan_control_state.sh enforces on read. Values a hand-edit
 # or bug put outside these are dropped rather than perpetuated.
 CONF_KEY_MAX = {"SYS_TGT": 150, "SYS_MAX": 150, "HDD_TGT": 150, "HDD_MAX": 150,
-                "SSD_TGT": 150, "SSD_MAX": 150, "MIN_FAN": 255}
+                "SSD_TGT": 150, "SSD_MAX": 150, "MIN_FAN": 255, "MAX_FAN": 255}
 
 # Curve parameters exposed as Home Assistant number entities. Ranges are hard
 # caps chosen to sit below the fixed *_MAX ceilings in fan_control.sh, so a
-# slider can never invert the curve (TGT >= MAX). MIN_FAN is exposed as a
+# slider can never invert the curve (TGT >= MAX). *_pct keys are exposed as a
 # percentage but stored raw (0-255) in the conf, matching fan_control.sh.
+# min/max fan sliders CAN cross (min 100%, max 30%); fan_control.sh treats an
+# inverted MAX_FAN < MIN_FAN as invalid and fails hot with the full range.
 PARAMS = {
-    "sys_tgt": {"conf_key": "SYS_TGT", "name": "System target temp", "min": 35, "max": 65, "unit": "°C"},
+    "sys_tgt": {"conf_key": "SYS_TGT", "name": "System target temp", "min": 35, "max": 70, "unit": "°C"},
     "hdd_tgt": {"conf_key": "HDD_TGT", "name": "HDD target temp", "min": 25, "max": 45, "unit": "°C"},
     "ssd_tgt": {"conf_key": "SSD_TGT", "name": "SSD target temp", "min": 35, "max": 62, "unit": "°C"},
-    "min_fan_pct": {"conf_key": "MIN_FAN", "name": "Minimum fan speed", "min": 10, "max": 100, "unit": "%"},
+    "min_fan_pct": {"conf_key": "MIN_FAN", "name": "Minimum fan speed", "min": 5, "max": 100, "unit": "%"},
+    "max_fan_pct": {"conf_key": "MAX_FAN", "name": "Maximum fan speed", "min": 30, "max": 100, "unit": "%"},
 }
 
 
@@ -414,8 +417,8 @@ def discovery_payload(conf, state):
                            "{{ value_json.tachs['%s'] }}" % tach, "rpm")
 
     for pkey, spec in PARAMS.items():
-        template = ("{{ (value_json.params.min_fan * 100 / 255) | round(0) }}"
-                    if pkey == "min_fan_pct"
+        template = ("{{ (value_json.params.%s * 100 / 255) | round(0) }}" % pkey[:-len("_pct")]
+                    if pkey.endswith("_pct")
                     else "{{ value_json.params.%s }}" % pkey)
         cmps[pkey] = {
             "p": "number",
@@ -582,8 +585,9 @@ class Bridge:
             log("Ignoring non-finite %s command: %r" % (pkey, payload))
             return
         value = clamp(round(value), spec["min"], spec["max"])
-        conf_value = pct_to_raw(value) if pkey == "min_fan_pct" else value
-        state_key = "min_fan" if pkey == "min_fan_pct" else pkey
+        is_pct = pkey.endswith("_pct")
+        conf_value = pct_to_raw(value) if is_pct else value
+        state_key = pkey[:-len("_pct")] if is_pct else pkey
         # The conf file is the source of truth for persisted overrides: merge
         # into whatever is already there (including hand-added keys), never
         # rebuild from possibly-empty in-memory state.
@@ -676,21 +680,25 @@ def selftest():
     # ({{ (raw * 100 / 255) | round(0) }}) a stable round-trip.
     assert clamp(200, 25, 45) == 45 and clamp(-5, 25, 45) == 25
     assert pct_to_raw(100) == 255 and pct_to_raw(10) == 26
-    for pct in range(10, 101):
+    for pct in range(5, 101):
         # resubmitting the displayed percentage must not change the raw value
         assert round(pct_to_raw(pct) * 100 / 255) == pct, pct
     assert pct_to_raw(round(39 * 100 / 255)) == 39  # the default MIN_FAN
     assert sanitize_id("WD-WX/1 2") == "WD-WX_1_2"
     # discovery payload sanity
-    conf = {"device_id": "unas", "discovery_prefix": "homeassistant"}
+    conf = {"device_id": "unas", "discovery_prefix": "homeassistant",
+            "device_url": "https://unas.local"}
     state = {"sys_temp": 50, "hdd_temp": 34, "ssd_temp": None, "fan_duty_pct": 25,
              "drives": {"WD1": {"class": "HDD", "dev": "/dev/sda", "temp": 34}},
              "tachs": {"adt7475_fan1": 3170},
-             "params": {"sys_tgt": 50, "hdd_tgt": 32, "ssd_tgt": 50, "min_fan": 39}}
+             "params": {"sys_tgt": 50, "hdd_tgt": 32, "ssd_tgt": 50,
+                        "min_fan": 39, "max_fan": 255}}
     d = discovery_payload(conf, state)
     assert d["dev"]["ids"] == ["unas"] and "o" in d
     assert d["cmps"]["drive_WD1"]["value_template"] == "{{ value_json.drives['WD1'].temp }}"
     assert d["cmps"]["hdd_tgt"]["p"] == "number" and d["cmps"]["hdd_tgt"]["max"] == 45
+    assert d["cmps"]["max_fan_pct"]["value_template"] == \
+        "{{ (value_json.params.max_fan * 100 / 255) | round(0) }}"
     assert d["cmps"]["tach_adt7475_fan1"]["unit_of_measurement"] == "rpm"
     assert "hdd_temp" in d["cmps"] and "ssd_temp" not in d["cmps"]  # null class omitted
     assert all("unique_id" in c for c in d["cmps"].values())

--- a/mqtt_bridge.service
+++ b/mqtt_bridge.service
@@ -1,0 +1,55 @@
+# MQTT bridge for the UNAS fan control service.
+#
+# Publishes temperatures/fan speeds to MQTT with Home Assistant discovery, and
+# accepts fan-curve tuning from Home Assistant. Entirely optional: without
+# /root/mqtt_bridge.conf this unit stays inactive (ConditionPathExists), so
+# installing it has no effect for non-MQTT users. Fan control itself never
+# depends on this unit.
+#
+# Repo: https://github.com/hoxxep/UNAS-Pro-fan-control
+# License: MIT
+
+[Unit]
+Description=MQTT bridge for fan_control (Home Assistant discovery)
+ConditionPathExists=/root/mqtt_bridge.conf
+After=network-online.target fan_control.service
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/bin/python3 /root/mqtt_bridge.py
+Restart=always
+RestartSec=10
+User=root
+# Keep the bridge strictly lightweight: hard memory cap (a leak gets the
+# process killed and cleanly restarted, never the NAS starved), a CPU quota,
+# and low scheduling priority so fan control and storage always win.
+MemoryMax=48M
+CPUQuota=25%
+Nice=10
+# Sandbox: this is the only network-facing process in the repo, parsing a
+# binary protocol from the broker, so confine it. It only needs to read
+# /root/mqtt_bridge.py + /root/mqtt_bridge.conf + /run/fan_control/state.json,
+# write /root/fan_control.conf, and open one outbound TCP connection.
+# NOTE: the code lives in /root, so ProtectHome=yes (masks /root) and
+# ProtectSystem=strict (needs ReadWritePaths=/root to punch back in) both
+# break here -- UniFi OS's systemd v247 does not honour ReadWritePaths=/root
+# over those masks, so the process gets EACCES reading its own script.
+# ProtectSystem=full leaves /root writable without any override, so use it.
+# If the bridge fails to start/connect after a UniFi OS update, bisect by
+# commenting these out (fan control itself is unaffected either way).
+NoNewPrivileges=yes
+UMask=0077
+ProtectSystem=full
+PrivateTmp=yes
+RestrictAddressFamilies=AF_INET AF_INET6
+CapabilityBoundingSet=
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
> [!NOTE]
> **Optional follow-up to #15** (MQTT / Home Assistant bridge). Please review and merge #15 first, on its own merits — this PR extends the bridge with a fan-noise ceiling and is entirely separate to accept or decline. Until #15 lands its commits appear in this diff too; once #15 is merged, this PR reduces to exactly the changes described below. Marked as draft until #15 is decided.

## Summary

Adds a **`MAX_FAN` fan-speed ceiling parameter** and retunes the default curve spans. Beyond the new knob itself, the changes implement a **noise optimization logic**: the fan controller no longer just chases temperatures — it also keeps the acoustic behavior smooth and bounded, while preserving every fail-hot safety guarantee.

## The noise problem

With the previous defaults (and especially after raising the `*_TGT` sliders toward the fixed `*_MAX` ceilings), the TGT→MAX span collapsed to 5–10 °C. That made the fan curve a cliff — up to ~45 PWM steps per °C — so 1–2 °C sensor wobble swung the fans by 20–90 PWM every minute: audible, constant pumping.

## The noise optimization logic

- **Curves ramp `MIN_FAN`→`MAX_FAN`** instead of `MIN_FAN`→255. Lowering `MAX_FAN` both caps peak speed and *flattens the slope*, so temperature wobble translates into small, slow PWM steps instead of audible swings.
- **Wider default spans:** `SYS_MAX` 75→85 °C, `HDD_MAX` 50→55 °C — slope drops to ~7–9 PWM/°C. Both ceilings stay within SoC throttle and HDD rating limits; 100 % remains reachable when heat demands it.
- **Safety unchanged / fail-hot:** invalid `MAX_FAN` (< `MIN_FAN` or > 255) is ignored and the full range is used; degenerate `TGT >= MAX` still fails hot; `--restore` / `ExecStopPost` untouched.

## Home Assistant

- New **“Maximum fan speed”** number entity (30–100 %, stored raw 0–255 like `MIN_FAN`).
- Minimum fan speed slider extended to 5–100 %; system target temp slider up to 70 °C.
- Bridge version bumped to 1.1.0; fixed a pre-existing `--selftest` KeyError (missing `device_url` in the test conf).

## Hardware verification (UNAS Pro, 6 HDD)

- Idle fan speed: **~3 900 → ~2 300 rpm**; perceived noise from unbearable to silent-adjacent.
- Fan duty: constant 50↔62 % oscillation → **steady 36 %** over a 14 h soak.
- Drive temps settled ~2 °C higher (hottest bay 48 °C), well within limits; full ramp headroom intact.

<img width="1362" height="1213" alt="image" src="https://github.com/user-attachments/assets/e6d64860-562b-4368-a22d-ac4113bb7016" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
